### PR TITLE
Rename `autoload/vimsuggest/aux.vim` to `autoload/vimsuggest/auxiliary.vim`

### DIFF
--- a/autoload/vimsuggest/auxiliary.vim
+++ b/autoload/vimsuggest/auxiliary.vim
@@ -240,7 +240,7 @@ def GetRange(rstr: string, isglobal: bool = false): list<number>
     return [startl, endl]
 enddef
 
-# :call g:vimsuggest#aux#TestRange() while editing ../../LICENSE.
+# :call g:vimsuggest#auxiliary#TestRange() while editing ../../LICENSE.
 export def TestRange()
     :normal gg
     assert_equal([line('.'), line('.')], GetRange(''))

--- a/autoload/vimsuggest/cmd.vim
+++ b/autoload/vimsuggest/cmd.vim
@@ -6,7 +6,7 @@ vim9script
 
 import autoload './popup.vim'
 import autoload './addons/addons.vim'
-import autoload './aux.vim'
+import autoload './auxiliary.vim'
 
 export var options: dict<any> = {
     enable: true,      # Enable/disable the completion functionality
@@ -205,7 +205,7 @@ def DoComplete(oldcontext: string, skip_none: bool, timer: number)
     catch # Catch (for ex.) -> E1245: Cannot expand <sfile> in a Vim9 function
     endtry
     if completions->len() == 0  # Try completing :s// and :g/
-        completions = aux.GetCompletionSG(context)
+        completions = auxiliary.GetCompletionSG(context)
         if completions->len() > 0 && &hlsearch && &incsearch
             # Restore 'hls' and 'incsearch' hightlight (removed when popup_show() redraws).
             var charpos = getcmdpos() - 2
@@ -254,9 +254,9 @@ enddef
 # When ':range' is present, insertion of completion text should happen at the
 # end of range. Similary, :s// and :g//.
 def InsertionPoint(replacement: string): number
-    if aux.insertion_point != -1
-        var temp = aux.insertion_point
-        aux.insertion_point = -1
+    if auxiliary.insertion_point != -1
+        var temp = auxiliary.insertion_point
+        auxiliary.insertion_point = -1
         return temp
     endif
     var context = Context()
@@ -343,7 +343,7 @@ def FilterFn(winid: number, key: string): bool
         CmdlineAbortHook()
         return false
     elseif key == "\<C-d>"
-    elseif aux.CursorMovementKey(key)
+    elseif auxiliary.CursorMovementKey(key)
         return false
     else
         if state.char_removed

--- a/autoload/vimsuggest/search.vim
+++ b/autoload/vimsuggest/search.vim
@@ -7,7 +7,7 @@ vim9script
 # functions to enhance the search experience in Vim.
 
 import autoload './popup.vim'
-import autoload './aux.vim'
+import autoload './auxiliary.vim'
 
 # Configuration options
 export var options: dict<any> = {
@@ -239,7 +239,7 @@ def FilterFn(winid: number, key: string): bool
             setreg('/', State.saved_searchreg) # Restore previous hlsearch
         endif
         return false  # 'false' causes search to be abandoned, and trigger CmdlineLeave
-    elseif aux.CursorMovementKey(key)
+    elseif auxiliary.CursorMovementKey(key)
         return false
     else
         IncSearchHighlightClear()


### PR DESCRIPTION
`aux` is a reserved filename on windows and prevents cloning of the repository: [https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file](https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file)

NOTE: I have not tested this fix on Windows yet